### PR TITLE
Move GH functions to JXDSLUtils, clean up code some

### DIFF
--- a/src/main/groovy/org/jenkinsci/plugins/jx/pipelines/dsl/JXDSLUtils.groovy
+++ b/src/main/groovy/org/jenkinsci/plugins/jx/pipelines/dsl/JXDSLUtils.groovy
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl
 
+import groovy.json.JsonSlurper
+import groovy.transform.Canonical
 import hudson.model.TaskListener
 import io.fabric8.kubernetes.api.model.Namespace
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
@@ -43,6 +45,12 @@ class JXDSLUtils {
         return listener
     }
 
+    /**
+     * Echoes the given message to the general Jenkins console for the run. Note that this will not prepend with the current
+     * parallel branch, unlike the echo step, so we may end up wanting to revert to using the echo step.
+     *
+     * @param msg
+     */
     @Whitelisted
     static void echo(String msg) {
         getListener().getLogger().println(msg)
@@ -179,4 +187,272 @@ class JXDSLUtils {
         return ExceptionUtils.getFullStackTrace(t)
     }
 
+    @Whitelisted
+    static String getDockerHubImageTags(String image) {
+        try {
+            return "https://registry.hub.docker.com/v1/repositories/${image}/tags".toURL().getText()
+        } catch (err) {
+            return "NO_IMAGE_FOUND"
+        }
+    }
+
+    @Canonical
+    private static final class GitHubResponse implements Serializable {
+        private static final long serialVersionUID = 1
+
+        Object result
+        int responseCode
+        String responseMessage
+    }
+
+    @Nonnull
+    private static GitHubResponse talkToGitHub(@Nonnull String method, @Nonnull String githubToken, @Nonnull URL apiUrl, String body = null) {
+        GitHubResponse resp = new GitHubResponse()
+        HttpURLConnection connection = apiUrl.openConnection()
+        if (githubToken.length() > 0) {
+            connection.setRequestProperty("Authorization", "Bearer ${githubToken}")
+        }
+        if (method == "PATCH") {
+            connection.setRequestProperty("X-HTTP-Method-Override", "PATCH");
+            connection.setRequestMethod("POST")
+        } else {
+            connection.setRequestMethod(method)
+        }
+        connection.setDoOutput(true)
+        connection.connect()
+
+        try {
+            if (body != null) {
+                OutputStreamWriter writer = new OutputStreamWriter(connection.getOutputStream())
+                writer.write(body)
+                writer.flush()
+            }
+            
+            // execute the POST request
+            resp.result = new JsonSlurper().parse(new InputStreamReader(connection.getInputStream(), "UTF-8"))
+            resp.responseCode = connection.responseCode
+            resp.responseMessage = connection.responseMessage
+        } finally {
+            connection.disconnect()
+        }
+        return resp
+    }
+    
+    @Whitelisted
+    static String createPullRequest(String message, String project, String branch, String githubToken) throws Exception {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/pulls")
+        echo "creating PR for ${apiUrl}"
+
+        def body = """
+    {
+      "title": "${message}",
+      "head": "${branch}",
+      "base": "master"
+    }
+    """
+
+        echo "sending body: ${body}\n"
+
+        def rs = talkToGitHub("POST", githubToken, apiUrl, body)
+
+        echo "Received PR id:  ${rs.result.number}"
+        return rs.result.number + ''
+
+    }
+
+    @Whitelisted
+    static void closePR(project, id, newVersion, newPRID, String githubToken) throws Exception {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/pulls/${id}")
+        echo "deleting PR for ${apiUrl}"
+
+        def body = """
+    {
+      "state": "closed",
+      "body": "Superseded by new version ${newVersion} #${newPRID}"
+    }
+    """
+        echo "sending body: ${body}\n"
+
+        GitHubResponse rs = talkToGitHub("PATCH", githubToken, apiUrl, body)
+        if (rs.responseCode != 200) {
+            throw new IllegalStateException("${project} PR ${id} not merged.  ${rs.getResponseMessage()}")
+
+        } else {
+            echo "${project} PR ${id} ${rs.result.message}"
+        }
+    }
+
+    @Whitelisted
+    static String getIssueComments(project, id, String githubToken) {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/issues/${id}/comments")
+        echo "getting comments for ${apiUrl}"
+
+        GitHubResponse rs = talkToGitHub("GET", githubToken, apiUrl)
+
+        if (rs.responseCode != 0 && rs.responseCode != 200) {
+            throw new IllegalStateException("Cannot get ${project} PR ${id} comments.  ${rs.getResponseMessage()}")
+        }
+
+        return rs.result
+    }
+
+    @Whitelisted
+    static boolean checkIfCommitIsSuccessful(project, ref, String githubToken) {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/commits/${ref}/status")
+
+        GitHubResponse rs
+        try {
+            rs = talkToGitHub("GET", githubToken, apiUrl)
+        } catch (err) {
+            echo "CI checks have not passed yet so waiting before merging"
+        }
+
+        if (rs == null) {
+            echo "Error getting commit status, are CI builds enabled for this PR?"
+            return false
+        }
+        if (rs != null && rs.result.state == 'success') {
+            return true
+        } else {
+            echo "Commit status is ${rs.result.state}.  Waiting to merge"
+            return false
+        }
+    }
+
+    @Whitelisted
+    static String getGithubBranch(project, id, String githubToken) {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/pulls/${id}")
+
+        try {
+            GitHubResponse rs = talkToGitHub("GET", githubToken, apiUrl)
+            def branch = rs.result.head.ref
+            echo "${branch}"
+            return branch
+        } catch (err) {
+            echo "Error while fetching the github branch"
+        }
+    }
+
+    @Whitelisted
+    static void mergePR(project, id, String githubToken) throws Exception {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/pulls/${id}/merge")
+
+        // execute the request
+        GitHubResponse rs = talkToGitHub("PUT", githubToken, apiUrl)
+
+        if (rs.responseCode != 200) {
+            if (rs.responseCode == 405) {
+                throw new IllegalStateException("${project} PR ${id} not merged.  ${rs.result.message}")
+            } else {
+                throw new IllegalStateException("${project} PR ${id} not merged.  GitHub API Response code: ${rs.responseCode}")
+            }
+        } else {
+            echo "${project} PR ${id} ${rs.result.message}"
+        }
+    }
+
+    @Whitelisted
+    static void squashAndMerge(project, id, String githubToken) throws Exception {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/pulls/${id}/merge")
+
+        def body = "{\"merge_method\":\"squash\"}"
+
+        def rs = talkToGitHub("POST", githubToken, apiUrl, body)
+
+        if (rs.responseCode != 200) {
+            if (rs.responseCode == 405) {
+                throw new IllegalStateException("${project} PR ${id} not merged.  ${rs.result.message}")
+            } else {
+                throw new IllegalStateException("${project} PR ${id} not merged.  GitHub API Response code: ${rs.responseCode}")
+            }
+        } else {
+            echo "${project} PR ${id} ${rs.result.message}"
+        }
+    }
+
+    @Whitelisted
+    static void addCommentToPullRequest(comment, pr, project, String githubToken) {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/issues/${pr}/comments")
+        echo "adding ${comment} to ${apiUrl}"
+
+        def body = "{\"body\":\"${comment}\"}"
+
+        talkToGitHub("POST", githubToken, apiUrl, body)
+    }
+
+    @Whitelisted
+    static void addMergeCommentToPullRequest(String pr, String project, String githubToken) {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/issues/${pr}/comments")
+        echo "merge PR using comment sent to ${apiUrl}"
+
+        def body = '{"body":"[merge]"}'
+
+        talkToGitHub("POST", githubToken, apiUrl, body)
+    }
+
+    @Whitelisted
+    static boolean isAuthorCollaborator(String changeAuthor, String githubToken, project) throws Exception {
+
+        if (!githubToken) {
+            echo "No GitHub api key found so trying annonynous GitHub api call"
+        }
+
+        if (!changeAuthor) {
+            throw new IllegalStateException("No commit author found.  Is this a pull request pipeline?")
+        }
+        echo "Checking if user ${changeAuthor} is a collaborator on ${project}"
+
+        def apiUrl = new URL("https://api.github.com/repos/${project}/collaborators/${changeAuthor}")
+
+        try {
+            GitHubResponse rs = talkToGitHub("GET", githubToken, apiUrl)
+            if (rs.responseCode != 200) {
+                return false
+            } else {
+                return true
+            }
+        } catch (FileNotFoundException e1) {
+            return false
+        } catch (Exception e) {
+            throw new IllegalStateException("Error checking if user ${changeAuthor} is a collaborator on ${project}.")
+        }
+    }
+
+    @Whitelisted
+    static String getUrlAsString(urlString) {
+
+        def url = new URL(urlString)
+        def scan
+        def response
+        echo "getting string from URL: ${url}"
+        try {
+            scan = new Scanner(url.openStream(), "UTF-8")
+            response = scan.useDelimiter("\\A").next()
+        } finally {
+            scan.close()
+        }
+        return response
+    }
+
+    @Whitelisted
+    static void drop(String pr, String project, String githubToken) throws Exception {
+        def apiUrl = new URL("https://api.github.com/repos/${project}/pulls/${pr}")
+        def branchName
+        echo "closing PR ${apiUrl}"
+
+
+        def body = '''
+    {
+      "body": "release aborted",
+      "state": "closed"
+    }
+    '''
+
+        def rs = talkToGitHub("POST", githubToken, apiUrl, body)
+        
+        branchName = rs.result.head.ref
+
+        apiUrl = new URL("https://api.github.com/repos/${project}/git/refs/heads/${branchName}")
+        talkToGitHub("DELETE", githubToken, apiUrl, body)
+    }
 }


### PR DESCRIPTION
This all *should* end up being changed to use the github-api library,
ideally with the backoff-retry logic for API rate limits that's used
in github-branch-source as well, but there's a core problem with that
currently: the token the plugin's expecting to use is a GitHub Apps
token, but github-api only supports OAuth tokens or username +
personal access tokens. So either we need to add GitHub Apps token
support to github-api (definitely doable), or we need to change the
expected authentication mechanism here.