### PR TITLE
Initial validation support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@
     <structs.version>1.10</structs.version>
     <workflow-cps.version>2.41</workflow-cps.version>
     <workflow-durable-task-step.version>2.17</workflow-durable-task-step.version>
-    <workflow-step-api-plugin.version>2.13</workflow-step-api-plugin.version>
+    <workflow-step-api-plugin.version>2.14</workflow-step-api-plugin.version>
     <workflow-support.version>2.16</workflow-support.version>
-
+    <declarative.version>1.2.6</declarative.version>
 
     <workflow-aggregator.version>2.5</workflow-aggregator.version>
     <!--
@@ -296,6 +296,11 @@
       <artifactId>bridge-method-annotation</artifactId>
       <version>1.17</version>
     </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-extensions</artifactId>
+      <version>1.2.6</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <!--
@@ -353,17 +358,24 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>jenkins-test-harness-tools</artifactId>
+      <version>2.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
       <artifactId>pipeline-model-definition</artifactId>
-      <version>1.2.4</version>
+      <version>${declarative.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-declarative-agent</artifactId>
-      <version>1.1.1</version>
+      <artifactId>pipeline-model-definition</artifactId>
+      <version>${declarative.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/BayesianScannerArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/BayesianScannerArguments.java
@@ -22,8 +22,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-
 /**
  */
 public class BayesianScannerArguments extends JXPipelinesArguments<BayesianScannerArguments> {

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/ContentRepositoryArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/ContentRepositoryArguments.java
@@ -22,8 +22,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-
 /**
  */
 public class ContentRepositoryArguments extends JXPipelinesArguments<ContentRepositoryArguments> {

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/JUnitResultsArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/JUnitResultsArguments.java
@@ -22,8 +22,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-
 /**
  */
 public class JUnitResultsArguments extends JXPipelinesArguments<JUnitResultsArguments> {

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/JXPipelinesArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/JXPipelinesArguments.java
@@ -7,7 +7,4 @@ import java.io.Serializable;
 
 public abstract class JXPipelinesArguments<T extends JXPipelinesArguments<T>> extends AbstractDescribableImpl<T> implements Serializable {
 
-    public abstract static class JXPipelinesArgumentsDescriptor<A extends JXPipelinesArguments<A>> extends Descriptor<A> {
-
-    }
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/JXPipelinesArgumentsDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/JXPipelinesArgumentsDescriptor.java
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.jx.pipelines.arguments;
+
+import hudson.model.Descriptor;
+
+public abstract class JXPipelinesArgumentsDescriptor<A extends JXPipelinesArguments<A>> extends Descriptor<A> {
+
+}

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/MavenFlowArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/MavenFlowArguments.java
@@ -29,7 +29,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/MavenReleaseArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/MavenReleaseArguments.java
@@ -22,8 +22,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-
 /**
  */
 public class MavenReleaseArguments extends JXPipelinesArguments<MavenReleaseArguments> {

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/PromoteArtifactsArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/PromoteArtifactsArguments.java
@@ -23,7 +23,6 @@ import org.jenkinsci.plugins.jx.pipelines.StepExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/PromoteImagesArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/PromoteImagesArguments.java
@@ -24,7 +24,6 @@ import org.jenkinsci.plugins.jx.pipelines.StepExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/ReleaseProjectArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/ReleaseProjectArguments.java
@@ -29,7 +29,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/SonarQubeScannerArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/SonarQubeScannerArguments.java
@@ -22,8 +22,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.Serializable;
-
 /**
  */
 public class SonarQubeScannerArguments extends JXPipelinesArguments<SonarQubeScannerArguments> {

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/StageExtraImagesArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/StageExtraImagesArguments.java
@@ -23,7 +23,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/StageProjectArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/StageProjectArguments.java
@@ -24,7 +24,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/TagImagesArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/TagImagesArguments.java
@@ -24,7 +24,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/WaitUntilArtifactSyncedArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/WaitUntilArtifactSyncedArguments.java
@@ -25,7 +25,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
-import java.io.Serializable;
 
 /**
  */

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/WaitUntilPullRequestMergedArguments.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/arguments/WaitUntilPullRequestMergedArguments.java
@@ -25,7 +25,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
-import java.io.Serializable;
 
 /**
  */

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXCommandsDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXCommandsDSL.java
@@ -16,9 +16,6 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
-
-import java.io.IOException;
 
 @Extension
 public class JXCommandsDSL extends PipelineDSLGlobal {
@@ -27,12 +24,4 @@ public class JXCommandsDSL extends PipelineDSLGlobal {
     public String getFunctionName() {
         return "jxCommands";
     }
-
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
-    }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXPipelinesValidator.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXPipelinesValidator.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.jx.pipelines.dsl;
+
+import hudson.Extension;
+import org.jenkinsci.plugins.pipeline.modeldefinition.ast.ModelASTStep;
+import org.jenkinsci.plugins.pipeline.modeldefinition.validator.DeclarativeValidatorContributor;
+import org.jenkinsci.plugins.workflow.flow.FlowExecution;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+@Extension
+public class JXPipelinesValidator extends DeclarativeValidatorContributor {
+    @CheckForNull
+    public String validateElement(@Nonnull ModelASTStep step, @CheckForNull FlowExecution execution) {
+        String stepName = step.getName();
+
+        PipelineDSLGlobal global = PipelineDSLGlobal.getGlobalForName(stepName);
+
+        // No matching global, so move on.
+        if (global == null) {
+            return null;
+        }
+
+        return global.validate(step);
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXPipelinesWhitelist.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXPipelinesWhitelist.java
@@ -23,9 +23,6 @@ import javax.annotation.Nonnull;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  */

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/MavenFlowDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/MavenFlowDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.MavenFlowArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class MavenFlowDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class MavenFlowDSL extends PipelineDSLGlobal {
         return "mavenFlow";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(MavenFlowArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/PromoteArtifactsDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/PromoteArtifactsDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.PromoteArtifactsArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class PromoteArtifactsDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class PromoteArtifactsDSL extends PipelineDSLGlobal {
         return "promoteArtifacts";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(PromoteArtifactsArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/PromoteImagesDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/PromoteImagesDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.PromoteImagesArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class PromoteImagesDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class PromoteImagesDSL extends PipelineDSLGlobal {
         return "promoteImages";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(PromoteImagesArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/ReleaseProjectDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/ReleaseProjectDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.ReleaseProjectArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class ReleaseProjectDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class ReleaseProjectDSL extends PipelineDSLGlobal {
         return "releaseProject";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(ReleaseProjectArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/StageProjectDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/StageProjectDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.StageProjectArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class StageProjectDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class StageProjectDSL extends PipelineDSLGlobal {
         return "stageProject";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(StageProjectArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/TagImagesDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/TagImagesDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.TagImagesArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class TagImagesDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class TagImagesDSL extends PipelineDSLGlobal {
         return "tagImages";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(TagImagesArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/WaitUntilArtifactSyncedWithCentralDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/WaitUntilArtifactSyncedWithCentralDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.WaitUntilArtifactSyncedArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class WaitUntilArtifactSyncedWithCentralDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class WaitUntilArtifactSyncedWithCentralDSL extends PipelineDSLGlobal {
         return "waitUntilArtifactSyncedWithCentral";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(WaitUntilArtifactSyncedArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/WaitUntilJenkinsPluginSyncedDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/WaitUntilJenkinsPluginSyncedDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.WaitUntilJenkinsPluginSyncedArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class WaitUntilJenkinsPluginSyncedDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class WaitUntilJenkinsPluginSyncedDSL extends PipelineDSLGlobal {
         return "waitUntilJenkinsPluginSynced";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(WaitUntilJenkinsPluginSyncedArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/WaitUntilPullRequestMergedDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/jx/pipelines/dsl/WaitUntilPullRequestMergedDSL.java
@@ -16,9 +16,11 @@
 package org.jenkinsci.plugins.jx.pipelines.dsl;
 
 import hudson.Extension;
-import org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.ProxyWhitelist;
+import hudson.ExtensionList;
+import org.jenkinsci.plugins.jx.pipelines.arguments.JXPipelinesArgumentsDescriptor;
+import org.jenkinsci.plugins.jx.pipelines.arguments.WaitUntilPullRequestMergedArguments;
 
-import java.io.IOException;
+import javax.annotation.CheckForNull;
 
 @Extension
 public class WaitUntilPullRequestMergedDSL extends PipelineDSLGlobal {
@@ -28,11 +30,9 @@ public class WaitUntilPullRequestMergedDSL extends PipelineDSLGlobal {
         return "waitUntilPullRequestMerged";
     }
 
-    @Extension
-    public static class MiscWhitelist extends ProxyWhitelist {
-        public MiscWhitelist() throws IOException {
-            super(createStaticWhitelist(), new JXPipelinesWhitelist());
-        }
+    @Override
+    @CheckForNull
+    public JXPipelinesArgumentsDescriptor getArgumentsType() {
+        return ExtensionList.lookup(JXPipelinesArgumentsDescriptor.class).get(WaitUntilPullRequestMergedArguments.DescriptorImpl.class);
     }
-
 }

--- a/src/test/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXPipelinesValidatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/jx/pipelines/dsl/JXPipelinesValidatorTest.java
@@ -1,0 +1,15 @@
+package org.jenkinsci.plugins.jx.pipelines.dsl;
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.AbstractModelDefTest;
+import org.jenkinsci.plugins.pipeline.modeldefinition.Messages;
+import org.junit.Test;
+
+public class JXPipelinesValidatorTest extends AbstractModelDefTest {
+
+    @Test
+    public void simpleValidationFailure() throws Exception {
+        expectError("simpleValidationFailure")
+                .logContains(Messages.ModelValidatorImpl_InvalidStepParameter("steveOrganisation", "cdOrganisation"))
+                .go();
+    }
+}

--- a/src/test/resources/errors/simpleValidationFailure.groovy
+++ b/src/test/resources/errors/simpleValidationFailure.groovy
@@ -1,0 +1,21 @@
+pipeline {
+    agent {
+        label "fabric8-maven"
+    }
+    stages {
+        stage('Maven Release') {
+            steps {
+                mavenFlow(
+                    steveOrganisation: "jstrachan",
+                    cdBranches: ['master']
+                ) {
+                    promoteArtifacts {
+                        pre {
+                            echo "====> hook invoked before promote artifacts!"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Note that the example we actually test for is built-in from
Declarative's own validation of `Describable`s, but I've also added
hooks for more detailed validation being added to the various *DSL
classes.

Also added an easy way to get the appropriate *Arguments descriptor
for a given *DSL class (currently unused but will be useful for
further validation) and got rid of a bunch of redundant whitelist
extensions. More tests and probably some more detailed validation to
come soon.